### PR TITLE
updated target platform

### DIFF
--- a/core.cfg
+++ b/core.cfg
@@ -1,17 +1,17 @@
 core=\
   mvn:com.dexels.thirdparty/osgi.extension.sun.misc/1.0.0,\
-  mvn:com.fasterxml.jackson.core/jackson-annotations/2.11.2,\
-  mvn:com.fasterxml.jackson.core/jackson-core/2.11.2,\
-  mvn:com.fasterxml.jackson.core/jackson-databind/2.11.2,\
-  mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.11.2,\
-  mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.11.2,\
-  mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.11.2,\
-  mvn:com.google.code.gson/gson/2.8.5,\
+  mvn:com.fasterxml.jackson.core/jackson-annotations/2.19.0,\
+  mvn:com.fasterxml.jackson.core/jackson-core/2.19.0,\
+  mvn:com.fasterxml.jackson.core/jackson-databind/2.19.0,\
+  mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-xml/2.19.0,\
+  mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/2.19.0,\
+  mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/2.19.0,\
+  mvn:com.google.code.gson/gson/2.13.1,\
   mvn:com.google.guava/guava/23.0,\
   mvn:com.google.protobuf/protobuf-java/3.10.0,\
   mvn:com.googlecode.javaewah/JavaEWAH/1.1.6,\
   mvn:com.hazelcast/hazelcast-all/3.10.2,\
-  mvn:com.ibm.icu/icu4j/65.1,\
+  mvn:com.ibm.icu/icu4j/77.1,\
   mvn:com.microsoft.sqlserver/mssql-jdbc/7.4.1.jre8,\
   mvn:com.oracle.database.jdbc/ojdbc8/19.7.0.0,\
   mvn:com.oracle.database.security/oraclepki/19.7.0.0,\
@@ -21,14 +21,14 @@ core=\
   mvn:io.projectreactor/reactor-core/3.4.11,\
   mvn:io.prometheus/simpleclient/0.8.1,\
   mvn:io.prometheus/simpleclient_common/0.8.1,\
-  mvn:io.reactivex.rxjava2/rxjava/2.2.19,\
+  mvn:io.reactivex.rxjava2/rxjava/2.2.21,\
   mvn:io.swagger/swagger-annotations/1.5.20,\
-  mvn:joda-time/joda-time/2.10,\
-  mvn:mysql/mysql-connector-java/8.0.27,\
+  mvn:joda-time/joda-time/2.14.0,\
+  mvn:mysql/mysql-connector-java/8.0.33,\
   mvn:net.jpountz.lz4/lz4/1.3.0,\
-  mvn:org.apache.commons/commons-text/1.3,\
-  mvn:org.apache.httpcomponents/httpclient-osgi/4.5.10,\
-  mvn:org.apache.httpcomponents/httpcore-osgi/4.4.12,\
+  mvn:org.apache.commons/commons-text/1.15.0,\
+  mvn:org.apache.httpcomponents/httpclient-osgi/4.5.14,\
+  mvn:org.apache.httpcomponents/httpcore-osgi/4.4.16,\
   mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.ant/1.10.5_1,\
   mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax-inject/1_3,\
   mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jcip-annotations/1.0_2,\
@@ -40,20 +40,20 @@ core=\
   mvn:org.apache.xbean/xbean-asm-util/4.20,\
   mvn:org.apache.xbean/xbean-bundleutils/4.20,\
   mvn:org.apache.xbean/xbean-finder/4.20,\
-  mvn:org.bouncycastle/bcpg-jdk15on/1.64,\
-  mvn:org.bouncycastle/bcpkix-jdk15on/1.64,\
-  mvn:org.bouncycastle/bcprov-jdk15on/1.64,\
-  mvn:org.codehaus.woodstox/stax2-api/4.2,\
-  mvn:org.json/json/20180813,\
+  mvn:org.bouncycastle/bcpg-jdk15on/1.70,\
+  mvn:org.bouncycastle/bcpkix-jdk15on/1.70,\
+  mvn:org.bouncycastle/bcprov-jdk15on/1.70,\
+  mvn:org.codehaus.woodstox/stax2-api/4.2.2,\
+  mvn:org.json/json/20250517,\
   mvn:org.jvnet.mimepull/mimepull/1.9.11,\
   mvn:org.jvnet.staxex/stax-ex/1.8.1,\
   mvn:org.mongodb/bson/4.3.3,\
   mvn:org.mongodb/mongodb-driver-core/4.3.3,\
   mvn:org.mongodb/mongodb-driver-sync/4.3.3,\
   mvn:org.mongodb/mongodb-driver-reactivestreams/4.3.3,\
-  mvn:org.postgresql/postgresql/42.2.0,\
-  mvn:org.reactivestreams/reactive-streams/1.0.3,\
-  mvn:org.yaml/snakeyaml/1.27,\
+  mvn:org.postgresql/postgresql/42.7.7,\
+  mvn:org.reactivestreams/reactive-streams/1.0.4,\
+  mvn:org.yaml/snakeyaml/2.4,\
   mvn:redis.clients/jedis/2.9.3
 
 osgi=\
@@ -65,7 +65,7 @@ osgi=\
 felix=\
   mvn:org.apache.aries.spifly/org.apache.aries.spifly.dynamic.bundle/1.3.4,\
   mvn:org.apache.aries/org.apache.aries.util/1.1.3,\
-  mvn:org.apache.felix/org.apache.felix.configadmin/1.9.20,\
+  mvn:org.apache.felix/org.apache.felix.configadmin/1.9.26,\
   mvn:org.apache.felix/org.apache.felix.eventadmin/1.6.2,\
   mvn:org.apache.felix/org.apache.felix.fileinstall/3.6.8,\
   mvn:org.apache.felix/org.apache.felix.inventory/1.0.6,\
@@ -107,50 +107,50 @@ pax=\
   mvn:org.ops4j.pax.web/pax-web-spi/7.4.3
 
 jetty=\
-  mvn:org.eclipse.jetty.websocket/javax-websocket-client-impl/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty.websocket/javax-websocket-server-impl/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty.websocket/websocket-api/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty.websocket/websocket-client/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty.websocket/websocket-common/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty.websocket/websocket-server/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty.websocket/websocket-servlet/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty/jetty-client/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty/jetty-continuation/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty/jetty-http/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty/jetty-io/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty/jetty-jaas/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty/jetty-proxy/9.4.44.v20210927,\
+  mvn:org.eclipse.jetty.websocket/javax-websocket-client-impl/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty.websocket/javax-websocket-server-impl/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty.websocket/websocket-api/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty.websocket/websocket-client/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty.websocket/websocket-common/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty.websocket/websocket-server/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty.websocket/websocket-servlet/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty/jetty-client/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty/jetty-continuation/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty/jetty-http/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty/jetty-io/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty/jetty-jaas/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty/jetty-proxy/9.4.57.v20241219,\
   mvn:org.eclipse.jetty/jetty-reactive-httpclient/1.1.4,\
-  mvn:org.eclipse.jetty/jetty-security/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty/jetty-server/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty/jetty-servlet/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty/jetty-servlets/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty/jetty-util/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty/jetty-util-ajax/9.4.44.v20210927,\
-  mvn:org.eclipse.jetty/jetty-xml/9.4.44.v20210927
+  mvn:org.eclipse.jetty/jetty-security/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty/jetty-server/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty/jetty-servlet/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty/jetty-servlets/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty/jetty-util/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty/jetty-util-ajax/9.4.57.v20241219,\
+  mvn:org.eclipse.jetty/jetty-xml/9.4.57.v20241219
 
 commons=\
-  mvn:commons-codec/commons-codec/1.11,\
+  mvn:commons-codec/commons-codec/1.21.0,\
   mvn:commons-dbcp/commons-dbcp/1.4,\
-  mvn:commons-fileupload/commons-fileupload/1.4,\
-  mvn:commons-io/commons-io/2.6,\
+  mvn:commons-fileupload/commons-fileupload/1.6.0,\
+  mvn:commons-io/commons-io/2.21.0,\
   mvn:commons-lang/commons-lang/2.6,\
   mvn:commons-logging/commons-logging/1.2,\
-  mvn:commons-net/commons-net/3.6,\
+  mvn:commons-net/commons-net/3.12.0,\
   mvn:commons-pool/commons-pool/1.6,\
-  mvn:org.apache.commons/commons-compress/1.20,\
+  mvn:org.apache.commons/commons-compress/1.28.0,\
   mvn:org.apache.commons/commons-email/1.5,\
-  mvn:org.apache.commons/commons-lang3/3.7,\
+  mvn:org.apache.commons/commons-lang3/3.20.0,\
   mvn:org.apache.commons/commons-math3/3.6.1,\
-  mvn:org.apache.commons/commons-pool2/2.5.0
+  mvn:org.apache.commons/commons-pool2/2.13.1
 
 asm=\
   mvn:org.ow2.asm/asm-all/5.2,\
-  mvn:org.ow2.asm/asm-analysis/9.2,\
-  mvn:org.ow2.asm/asm-commons/9.2,\
-  mvn:org.ow2.asm/asm-tree/9.2,\
-  mvn:org.ow2.asm/asm-util/9.2,\
-  mvn:org.ow2.asm/asm/9.2
+  mvn:org.ow2.asm/asm-analysis/9.9.1,\
+  mvn:org.ow2.asm/asm-commons/9.9.1,\
+  mvn:org.ow2.asm/asm-tree/9.9.1,\
+  mvn:org.ow2.asm/asm-util/9.9.1,\
+  mvn:org.ow2.asm/asm/9.9.1
 
 jgit=\
   mvn:org.eclipse.jgit/org.eclipse.jgit.archive/5.4.0.201906121030-r,\

--- a/targetplatform.cfg
+++ b/targetplatform.cfg
@@ -1,11 +1,11 @@
 targetplatform=\
   mvn:com.nimbusds/nimbus-jose-jwt/9.37.3,\
-  mvn:junit/junit/4.13,\
-  mvn:net.bytebuddy/byte-buddy-agent/1.10.5,\
-  mvn:net.bytebuddy/byte-buddy/1.10.5,\
-  mvn:net.minidev/accessors-smart/2.5.0,\
-  mvn:net.minidev/json-smart/2.5.0,\
-  mvn:org.apache.httpcomponents/httpasyncclient-osgi/4.1.4,\
+  mvn:junit/junit/4.13.2,\
+  mvn:net.bytebuddy/byte-buddy-agent/1.17.5,\
+  mvn:net.bytebuddy/byte-buddy/1.17.5,\
+  mvn:net.minidev/accessors-smart/2.5.2,\
+  mvn:net.minidev/json-smart/2.5.2,\
+  mvn:org.apache.httpcomponents/httpasyncclient-osgi/4.1.5,\
   mvn:org.apache.pdfbox/fontbox/1.7.1,\
   mvn:org.apache.pdfbox/jempbox/1.7.1,\
   mvn:org.apache.pdfbox/pdfbox/1.7.1,\
@@ -17,30 +17,30 @@ targetplatform=\
   mvn:org.hamcrest/hamcrest-all/1.3,\
   mvn:org.mockito/mockito-core/3.2.4,\
   mvn:org.objenesis/objenesis/2.6,\
-  mvn:org.scala-lang/scala-compiler/2.12.12,\
-  mvn:org.scala-lang/scala-library/2.12.12,\
-  mvn:org.scala-lang/scala-reflect/2.12.12,\
+  mvn:org.scala-lang/scala-compiler/2.12.20,\
+  mvn:org.scala-lang/scala-library/2.12.20,\
+  mvn:org.scala-lang/scala-reflect/2.12.20,\
   mvn:org.slf4j/slf4j-api/1.7.28,\
   mvn:org.slf4j/slf4j-simple/1.7.28
 
 junit5=\
-  mvn:org.junit.jupiter/junit-jupiter/5.8.2,\
-  mvn:org.junit.jupiter/junit-jupiter-api/5.8.2,\
-  mvn:org.junit.jupiter/junit-jupiter-engine/5.8.2,\
-  mvn:org.junit.jupiter/junit-jupiter-migrationsupport/5.8.2,\
-  mvn:org.junit.jupiter/junit-jupiter-params/5.8.2,\
-  mvn:org.junit.platform/junit-platform-commons/1.8.2,\
-  mvn:org.junit.platform/junit-platform-console/1.8.2,\
-  mvn:org.junit.platform/junit-platform-engine/1.8.2,\
-  mvn:org.junit.platform/junit-platform-jfr/1.8.2,\
-  mvn:org.junit.platform/junit-platform-launcher/1.8.2,\
-  mvn:org.junit.platform/junit-platform-reporting/1.8.2,\
-  mvn:org.junit.platform/junit-platform-runner/1.8.2,\
-  mvn:org.junit.platform/junit-platform-suite/1.8.2,\
-  mvn:org.junit.platform/junit-platform-suite-api/1.8.2,\
-  mvn:org.junit.platform/junit-platform-suite-commons/1.8.2,\
-  mvn:org.junit.platform/junit-platform-suite-engine/1.8.2,\
-  mvn:org.junit.platform/junit-platform-testkit/1.8.2,\
-  mvn:org.junit.vintage/junit-vintage-engine/5.8.2,\
+  mvn:org.junit.jupiter/junit-jupiter/5.12.2,\
+  mvn:org.junit.jupiter/junit-jupiter-api/5.12.2,\
+  mvn:org.junit.jupiter/junit-jupiter-engine/5.12.2,\
+  mvn:org.junit.jupiter/junit-jupiter-migrationsupport/5.12.2,\
+  mvn:org.junit.jupiter/junit-jupiter-params/5.12.2,\
+  mvn:org.junit.platform/junit-platform-commons/1.12.2,\
+  mvn:org.junit.platform/junit-platform-console/1.12.2,\
+  mvn:org.junit.platform/junit-platform-engine/1.12.2,\
+  mvn:org.junit.platform/junit-platform-jfr/1.12.2,\
+  mvn:org.junit.platform/junit-platform-launcher/1.12.2,\
+  mvn:org.junit.platform/junit-platform-reporting/1.12.2,\
+  mvn:org.junit.platform/junit-platform-runner/1.12.2,\
+  mvn:org.junit.platform/junit-platform-suite/1.12.2,\
+  mvn:org.junit.platform/junit-platform-suite-api/1.12.2,\
+  mvn:org.junit.platform/junit-platform-suite-commons/1.12.2,\
+  mvn:org.junit.platform/junit-platform-suite-engine/1.12.2,\
+  mvn:org.junit.platform/junit-platform-testkit/1.12.2,\
+  mvn:org.junit.vintage/junit-vintage-engine/5.12.2,\
   mvn:org.apiguardian/apiguardian-api/1.1.2,\
-  mvn:org.opentest4j/opentest4j/1.2.0
+  mvn:org.opentest4j/opentest4j/1.3.0


### PR DESCRIPTION
## Update third-party dependencies across target platform

### Summary
- Update all safe-to-upgrade third-party dependencies in `core.cfg` and `targetplatform.cfg`
- Prioritize security-critical packages (CVEs in Jackson, SnakeYAML, commons-text, commons-compress, Jetty, PostgreSQL, Bouncy Castle)
- Verified all updates against OSGi `Import-Package` version ranges in navajo and cashless-backend repos

### Changes

#### core.cfg

| Package | Old | New | Reason |
|---|---|---|---|
| Jackson (6 modules) | 2.11.2 | 2.19.0 | Multiple CVEs |
| Bouncy Castle (3 modules) | 1.64 | 1.70 | Security fixes |
| Jetty (21 modules) | 9.4.44 | 9.4.57 | Security patches |
| SnakeYAML | 1.27 | 2.4 | Multiple CVEs |
| commons-text | 1.3 | 1.15.0 | CVE-2022-42889 (critical RCE) |
| commons-compress | 1.20 | 1.28.0 | CVEs |
| PostgreSQL | 42.2.0 | 42.7.7 | CVEs |
| Gson | 2.8.5 | 2.13.1 | |
| ICU4J | 65.1 | 77.1 | |
| org.json | 20180813 | 20250517 | |
| joda-time | 2.10 | 2.14.0 | |
| RxJava2 | 2.2.19 | 2.2.21 | Final patch |
| mysql-connector-java | 8.0.27 | 8.0.33 | |
| httpclient-osgi | 4.5.10 | 4.5.14 | |
| httpcore-osgi | 4.4.12 | 4.4.16 | |
| commons-codec | 1.11 | 1.21.0 | |
| commons-io | 2.6 | 2.21.0 | |
| commons-lang3 | 3.7 | 3.20.0 | |
| commons-pool2 | 2.5.0 | 2.13.1 | |
| commons-fileupload | 1.4 | 1.6.0 | |
| commons-net | 3.6 | 3.12.0 | |
| stax2-api | 4.2 | 4.2.2 | |
| reactive-streams | 1.0.3 | 1.0.4 | |
| felix configadmin | 1.9.20 | 1.9.26 | |
| ASM (5 modules) | 9.2 | 9.9.1 | |
| jsoup | 1.18.3 | 1.21.1 | |

#### targetplatform.cfg

| Package | Old | New |
|---|---|---|
| JUnit | 4.13 | 4.13.2 |
| byte-buddy (2 modules) | 1.10.5 | 1.17.5 |
| accessors-smart | 2.5.0 | 2.5.2 |
| json-smart | 2.5.0 | 2.5.2 |
| httpasyncclient-osgi | 4.1.4 | 4.1.5 |
| Scala (3 modules) | 2.12.12 | 2.12.20 |
| JUnit Jupiter (5 modules) | 5.8.2 | 5.12.2 |
| JUnit Platform (11 modules) | 1.8.2 | 1.12.2 |
| opentest4j | 1.2.0 | 1.3.0 |

### Compatibility verification

All updates were verified against OSGi `Import-Package` version ranges in the **navajo** and **cashless-backend** repos. Key ranges checked:

| Constraint | Range | Updated version | Status |
|---|---|---|---|
| Jackson | `[2.11.0,3.0.0)` | 2.19.0 | OK |
| commons-compress | `[1.5.0,2.0.0)` | 1.28.0 | OK |
| commons-pool2 | `[2.5.0,3.0.0)` | 2.13.1 | OK |
| commons-codec | `[1.11.0,2.0.0)` | 1.21.0 | OK |
| Jetty | `[8.0.0,10.0.0)` | 9.4.57 | OK |
| jsoup | `[1.18.0,2.0.0)` | 1.21.1 | OK |
| SLF4J | `[1.6.1,1.8.0)` | 1.7.28 (unchanged) | OK |

### Not updated (blocked by OSGi version ranges or breaking API changes)

| Package | Current | Latest | Blocker |
|---|---|---|---|
| Guava | 23.0 | 33.x | `[23.0.0,24.0.0)` in navajo + cashless |
| Jedis | 2.9.3 | 6.x | `[2.9.0,3.0.0)` in navajo |
| JGit | 5.4.0 | 7.x | `[3.0.0,6.0.0)` in navajo |
| SLF4J | 1.7.28 | 2.x | `[1.6.1,1.8.0)` in 20+ manifests |
| pax-logging | 1.11.7 | 2.x | `[1.11.0,2.0.0)` in cashless |
| pax-web | 7.4.3 | 9.x | Major API changes |
| protobuf-java | 3.10.0 | 4.x | Major version |
| MongoDB | 4.3.3 | 5.x | Major version |

Updating these would require coordinated MANIFEST.MF changes across navajo and cashless-backend.

### Test plan

- [ ] Build dexels-base target platform
- [ ] Build navajo against updated target platform
- [ ] Build cashless-backend against updated target platform
- [ ] Deploy to test environment and verify OSGi bundle resolution
- [ ] Smoke test core functionality (HTTP, database, JSON processing)
